### PR TITLE
Fix Kubectl responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,7 @@ images-clean: ## Remove docker image
 	docker rmi -f ${DOCKER_USER}/${DOCKER_IMAGE}:${DOCKER_TAG}
 
 .PHONY: test
-test: ## Run both unit and e2e tests
-	test-unit test-e2e
+test: test-unit test-e2e
 
 .PHONY: test-unit
 test-unit: ## Run all unit tests

--- a/pkg/reschedule/config.go
+++ b/pkg/reschedule/config.go
@@ -1,6 +1,7 @@
 package reschedule
 
 import (
+	"log/slog"
 	"os"
 	"strconv"
 
@@ -41,6 +42,16 @@ func (c *Config) ToEnvironment() map[string]string {
 	env["TRACK_RESCHEULED_PODS"] = strconv.FormatBool(c.trackRescheduledPods)
 	env["TRACKING_RESOURCE_TYPE"] = c.trackingResource.GetResourceType()
 	return env
+}
+
+func (c *Config) Print() {
+	slog.Info("Config loaded",
+		"rescheduleAnnotationKey", c.rescheduleAnnotationKey,
+		"rescheduleAnnotationValue", c.rescheduleAnnotationValue,
+		"podLabelSelectorKey", c.podLabelSelectorKey,
+		"podLabelSelectorValue", c.podLabelSelectorValue,
+		"trackRescheduledPods", c.trackRescheduledPods,
+		"trackingResource", c.trackingResource.GetResourceType())
 }
 
 // ConfigBuilder helps construct a Config with validation

--- a/pkg/reschedule/reschedule_test.go
+++ b/pkg/reschedule/reschedule_test.go
@@ -95,7 +95,7 @@ func TestHandleEviction(t *testing.T) {
 			mockClient: &mockClient{
 				pod: nil,
 			},
-			expectedResult: allowEviction(),
+			expectedResult: denyEviction(http.StatusNotFound, metav1.StatusReasonNotFound, PodRescheduledMsg),
 		},
 		{
 			testname:       "Ignore non-couchbase pods",
@@ -185,7 +185,7 @@ func TestHandleEviction(t *testing.T) {
 				shouldAddTrackingAnnotation: true,
 			},
 			expectedTrackingResourceAnnotations: map[string]string{},
-			expectedResult:                      allowEviction(),
+			expectedResult:                      denyEviction(http.StatusNotFound, metav1.StatusReasonNotFound, PodRescheduledWithSameNameMsg),
 		},
 		{
 			testname:       "Deny eviction with TooManyRequests if different pod is tracked, but this pod is missing reschedule annotation",


### PR DESCRIPTION
Instead of allowing the eviction when pods have been rescheduled, returning a 404 not found has the same effect but works more gracefully with kubectl. It also means when a pod is rescheduled with the same name, it isn't immediately deleted due to the eviction request being allowed.